### PR TITLE
add vm.tiktok.com for supported urls

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -52,6 +52,9 @@
               <data
                 android:scheme="https"
                 android:host="tiktok.com" />
+              <data
+                android:scheme="https"
+                android:host="vm.tiktok.com" />
             </intent-filter>
         </activity>
         <provider


### PR DESCRIPTION
vm. are direct links to videos

Like https://vm.tiktok.com/ZSpdohha/ for example that is expanded to https://www.tiktok.com/@johnvanb/video/6870536778642771201 with some garbage at the end.

To create a vm link just share a video from TikTokLite.